### PR TITLE
fix: remove Immutable flag before writing efi vars

### DIFF
--- a/efivar/Cargo.toml
+++ b/efivar/Cargo.toml
@@ -27,6 +27,7 @@ lazy_static = "1.4.0"
 ntapi = "0.4.1"
 winapi = { version = "0.3.9", features = ["errhandlingapi"] }
 thiserror = "1.0.49"
+rustix = { version = "0.38.30", features = ["fs"] }
 
 [features]
 store = ["base64", "serde", "serde_derive", "toml"]


### PR DESCRIPTION
EFI vars are marked as Immutable on many Linux systems. In those cases, the library would fail to write variables.

This change fixes that by removing the Immutable flag beforehand, and adding it back afterwards. It's essentially equivalent to the commands:
```sh
chattr -i /sys/firmware/efi/efivars/$VAR
# write to variable...
chattr +i /sys/firmware/efi/efivars/$VAR
```