### PR TITLE
Fix for weird boot entries where parser would panic

### DIFF
--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -109,7 +109,7 @@ impl DevicePath {
 
         let data_size = length - 1 - 1 - 2;
 
-        if data_size > buf.len() {
+        if data_size as usize > buf.len() {
             return Err(Error::VarParseError);
         }
         

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -110,9 +110,9 @@ impl DevicePath {
         let data_size = length - 1 - 1 - 2;
 
         if data_size as usize > buf.len() {
-            return Err(Error::VarParseError);
+                return Err(Error::VarParseError);
         }
-        
+
         let (mut device_path_data, new_buf) = buf.split_at(data_size.into());
         *buf = new_buf;
 

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -110,7 +110,7 @@ impl DevicePath {
         let data_size = length - 1 - 1 - 2;
 
         if data_size as usize > buf.len() {
-                return Err(Error::VarParseError);
+            return Err(Error::VarParseError);
         }
 
         let (mut device_path_data, new_buf) = buf.split_at(data_size.into());

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -109,6 +109,10 @@ impl DevicePath {
 
         let data_size = length - 1 - 1 - 2;
 
+        if data_size > buf.len() {
+            return Err(Error::VarParseError);
+        }
+        
         let (mut device_path_data, new_buf) = buf.split_at(data_size.into());
         *buf = new_buf;
 


### PR DESCRIPTION
split_at will panic if the data_size > buf.len()